### PR TITLE
Remove the traefik cookbook from Terraform

### DIFF
--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -1,6 +1,5 @@
 {
-  "repository": [
-    {
+  "repository": [{
       "name": "apache2",
       "repo_type": "cookbook"
     },
@@ -588,10 +587,6 @@
     },
     {
       "name": "transmission",
-      "repo_type": "cookbook"
-    },
-    {
-      "name": "traefik",
       "repo_type": "cookbook"
     },
     {


### PR DESCRIPTION
This cookbook has now been moved to the sous-chefs-boneyard
