### PR TITLE
Create new cookbook cinc-omnibus

### DIFF
--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -76,6 +76,10 @@
       "repo_type": "cookbook"
     },
     {
+      "name": "cinc-omnibus",
+      "repo_type": "cookbook"
+    },
+    {
       "name": "confluence",
       "repo_type": "cookbook"
     },


### PR DESCRIPTION
This is a new cookbook which basically replaces the deprecated omnibus cookbook. This will be primarily used by the Cinc Project to manage the various builders.

Signed-off-by: Lance Albertson <lance@osuosl.org>
