### PR TITLE
Disable security_and_analysis block due to failures

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -20,17 +20,22 @@ resource "github_repository" "this" {
   license_template       = "apache-2.0"
   archive_on_destroy     = true
   vulnerability_alerts   = true
-  security_and_analysis {
-    advanced_security {
-      status = "enabled"
-    }
-    secret_scanning {
-      status = "enabled"
-    }
-    secret_scanning_push_protection {
-      status = "enabled"
-    }
-  }
+  # TODO(ramereth): This currently causes the following error:
+  # 422 Advanced security is always available for public repos []
+  #
+  # Disabled until the following PR is merged and released:
+  # https://github.com/integrations/terraform-provider-github/pull/1431
+  # security_and_analysis {
+  #   advanced_security {
+  #     status = "enabled"
+  #   }
+  #   secret_scanning {
+  #     status = "enabled"
+  #   }
+  #   secret_scanning_push_protection {
+  #     status = "enabled"
+  #   }
+  # }
 }
 
 resource "github_branch" "default" {


### PR DESCRIPTION
This currently causes the following error (which was introduced in #35):
```
422 Advanced security is always available for public repos []
```
This can be uncommented once this [PR](https://github.com/integrations/terraform-provider-github/pull/1431)  is merged and released:

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
